### PR TITLE
Add temporary stripe stats url.

### DIFF
--- a/p2k16/roles/p2k16/templates/etc/nginx/sites-enabled/p2k16.j2
+++ b/p2k16/roles/p2k16/templates/etc/nginx/sites-enabled/p2k16.j2
@@ -35,6 +35,11 @@ server {
         try_files $uri $uri/ =404;
     }
 
+    location /stripe-stats.png {
+	root /home/haavares/charts;
+	try_files $uri $uri/ =404;
+    }
+
     location / {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Provide a path to show stripe stats graph, requested by the board.