### PR TITLE
bomba: o Adding all of the mosquitto config in git.

### DIFF
--- a/bomba/README.md
+++ b/bomba/README.md
@@ -1,3 +1,3 @@
 # Configure Mosquitto
 
-    ansible-playbook bomba.yml --tags mosquitto
+    ansible-playbook bomba.yml --tags mosquitto-server

--- a/bomba/roles/mosquitto-server/files/etc/letsencrypt/renewal-hooks/deploy/mosquitto-server
+++ b/bomba/roles/mosquitto-server/files/etc/letsencrypt/renewal-hooks/deploy/mosquitto-server
@@ -1,17 +1,19 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 for domain in $RENEWED_DOMAINS; do
   case $domain in
   mqtt.bitraf.no)
     umask 077
 
-    cp "$RENEWED_LINEAGE/fullchain.pem" "/etc/mosquitto/certs/$domain-fullchain.pem"
-    cp "$RENEWED_LINEAGE/privkey.pem" "/etc/mosquitto/certs/$domain-privkey.pem"
+    certs="/etc/mosquitto/certs"
 
-    chown mosquitto "/etc/mosquitto/certs/$domain-fullchain.pem" "/etc/mosquitto/certs/$domain-privkey.pem"
-    chmod 400 "/etc/mosquitto/certs/$domain-fullchain.pem" "/etc/mosquitto/certs/$domain-privkey.pem"
+    cp "${RENEWED_LINEAGE}/fullchain.pem" "${certs}/${domain}-fullchain.pem"
+    cp "${RENEWED_LINEAGE}/privkey.pem" "${certs}/${domain}-privkey.pem"
+
+    chown mosquitto "${certs}/${domain}-fullchain.pem" "${certs}/${domain}-privkey.pem"
+    chmod 400 "${certs}/${domain}-fullchain.pem" "${certs}/${domain}-privkey.pem"
 
     systemctl restart mosquitto
     ;;

--- a/bomba/roles/mosquitto-server/files/etc/mosquitto/bitraf.conf
+++ b/bomba/roles/mosquitto-server/files/etc/mosquitto/bitraf.conf
@@ -1,9 +1,0 @@
-# WARNING
-# WARNING This file is managed with ansible
-# WARNING
-
-#log_dest stdout
-
-allow_anonymous true
-acl_file /etc/mosquitto/conf.d/bitraf.acl
-password_file /etc/mosquitto/conf.d/bitraf.passwords

--- a/bomba/roles/mosquitto-server/tasks/main.yml
+++ b/bomba/roles/mosquitto-server/tasks/main.yml
@@ -24,15 +24,6 @@
         - etc/mosquitto/mosquitto.conf
         - etc/mosquitto/bitraf.acl
 
-    - name: Remove old files
-      file:
-        path: "{{ item }}"
-        state: absent
-      with_items:
-        - etc/mosquitto/conf.d/bitraf.passwords
-        - etc/mosquitto/conf.d/bitraf.acl
-        - etc/mosquitto/conf.d/bitraf.conf
-
 - name: Password management
   tags: mosquitto-passwd
   block:


### PR DESCRIPTION
o Enabling SSL on port 8883 and MQTT over Websocket over TLS on port
  9001 (wss://..).
o Adding deploy hook for letsencrypt so when the certificates are
  rotated, the certificates are copied to mosquitto and permissions
  adjusted.