### PR TITLE
mediawiki: increase max file upload size to 20M

### DIFF
--- a/shared-roles/mediawiki/handlers/main.yml
+++ b/shared-roles/mediawiki/handlers/main.yml
@@ -1,8 +1,3 @@
-- name: systemctl restart nginx
-  systemd:
-    name: nginx
-    state: restarted
-
 - name: service restart php-fpm
   become: yes
   service:

--- a/shared-roles/mediawiki/handlers/main.yml
+++ b/shared-roles/mediawiki/handlers/main.yml
@@ -2,3 +2,10 @@
   systemd:
     name: nginx
     state: restarted
+
+- name: service restart php-fpm
+  become: yes
+  service:
+    name: php7.0-fpm
+    state: restarted
+

--- a/shared-roles/mediawiki/tasks/main.yml
+++ b/shared-roles/mediawiki/tasks/main.yml
@@ -23,11 +23,17 @@
     - mediawiki-php
   block:
     - name: increase maximum file size (for uploads) to 20M
+      notify: service restart php-fpm
       ini_file:
         path: /etc/php/7.0/fpm/php.ini
         section: PHP
-        option: post_max_size
-        value: 20M
+        option: "{{ item.option }}"
+        value: "{{ item.value }}"
+      with_items:
+        - option: upload_max_filesize
+          value: 20M
+        - option: post_max_size
+          value: 20M
 
 - become: yes
   tags:


### PR DESCRIPTION
two parameters in php.ini needs changing for mediawiki 1.31 / php 7.0 in order to increase max file size for uploads, and a restart of php is required. This version is tested and working.