### PR TITLE
mediawiki: change nginx config, needed in addition to php.ini changes…

### DIFF
--- a/templates/nginx/mediawiki/sites-enabled/mediawiki
+++ b/templates/nginx/mediawiki/sites-enabled/mediawiki
@@ -11,6 +11,8 @@ server {
 
   root /var/www/html;
 
+  client_max_body_size 21M;
+
   # From https://www.mediawiki.org/wiki/Manual:Short_URL/Nginx
   location /{{ w }} {
     alias /opt/mediawiki/mediawiki;


### PR DESCRIPTION
… to allow uploads of files larger than 1M. The required PHP changes were fixed in #65, but it turns out that changes to nginx is also required.
Note: we use nginx on bitnode as a proxy; that one also needs a change (it has been suggested to set it to a large value like 100M) in order for this to work.