### PR TITLE
Readme: remember post-hook so nginx is reloaded

### DIFF
--- a/p2k16/README.md
+++ b/p2k16/README.md
@@ -30,7 +30,8 @@ Letsencrypt / HTTPS
 
     certbot run --installer nginx -d p2k16.bitraf.no \
       --authenticator webroot \
-      --webroot /var/www/p2k16.bitraf.no
+      --webroot /var/www/p2k16.bitraf.no \
+      --post-hook 'systemctl reload nginx'
 
 https://github.com/certbot/certbot/issues/5405#issuecomment-356498627
 


### PR DESCRIPTION
Found one place letsencrypt was referenced in our infra. This is it.

So add post-hook to it. It seems this part is not handled by Ansible, so I'll add it manually for bitraf.no.