### PR TITLE
wiki: change default skin from bitraf to vector

### DIFF
--- a/templates/mediawiki/LocalSettings.php
+++ b/templates/mediawiki/LocalSettings.php
@@ -128,7 +128,7 @@ $wgDiff3 = "/usr/bin/diff3";
 
 ## Default skin: you can change the default skin. Use the internal symbolic
 ## names, ie 'vector', 'monobook':
-$wgDefaultSkin = "bitraf";
+$wgDefaultSkin = "vector";
 
 # Enabled skins.
 # The following skins were automatically enabled:


### PR DESCRIPTION
Unfortunately, the 'bitraf' skin is broken, and unmaintained. So switch to 'vector' skin instead.