### PR TITLE
bomba/mosquitto-server: disallow p2k16-staging from unlocking tools

### DIFF
--- a/bomba/roles/mosquitto-server/files/etc/mosquitto/bitraf.acl
+++ b/bomba/roles/mosquitto-server/files/etc/mosquitto/bitraf.acl
@@ -121,8 +121,6 @@ topic write /public/#
 
 user bitraf-p2k16-web-staging
 topic readwrite bitraf/bitraf-p2k16-web-staging/#
-topic write bitraf/tool/+/unlock
-topic write bitraf/tool/+/lock
 topic write /public/#
 
 # Misc sensors


### PR DESCRIPTION
fix #124