### PR TITLE
Add service/timer for removing old wal-e backups

### DIFF
--- a/shared-roles/postgresql-wal-e/tasks/main.yml
+++ b/shared-roles/postgresql-wal-e/tasks/main.yml
@@ -117,3 +117,39 @@
         enabled: yes
         masked: no
         name: postgresql-base-backup@{{ pwe_major }}-{{ pwe_instance }}.timer
+
+    - name: systemd base backup service cleaner
+      register: base_backup_cleaner_service
+      copy:
+        dest: /etc/systemd/system/postgresql-base-backup-cleaner@.service
+        content: |
+          [Unit]
+          Description=PostgreSQL base backup cleaner
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/bin/env bash -c 'i="%i"; i=${i/-//}; bin/envdir /etc/wal-e/%i-env.d bin/wal-e delete --retain {{ pwe_retain }} --confirm'
+          WorkingDirectory={{ pwe_venv }}
+          User=postgres
+
+    - name: systemd base backup cleaner timer
+      register: base_backup_cleaner_timer
+      copy:
+        dest: /etc/systemd/system/postgresql-base-backup-cleaner@.timer
+        content: |
+          [Unit]
+          Description=PostgreSQL base backup cleaner timer
+
+          [Timer]
+          OnCalendar=Sun 05:00
+
+          [Install]
+          WantedBy=timers.target
+
+    - name: systemd daemon-reload
+      when: base_backup_cleaner_service.changed or base_backup_cleaner_timer.changed
+      systemd:
+        daemon_reload: yes
+        enabled: yes
+        masked: no
+        name: postgresql-base-backup-cleaner@{{ pwe_major }}-{{ pwe_instance }}.timer

--- a/shared-roles/postgresql-wal-e/tasks/main.yml
+++ b/shared-roles/postgresql-wal-e/tasks/main.yml
@@ -128,7 +128,7 @@
 
           [Service]
           Type=oneshot
-          ExecStart=/usr/bin/env bash -c 'i="%i"; i=${i/-//}; bin/envdir /etc/wal-e/%i-env.d bin/wal-e delete --retain {{ pwe_retain }} --confirm'
+          ExecStart=/usr/bin/env bash -c 'i="%i"; i=${i/-//}; bin/envdir /etc/wal-e/%i-env.d bin/wal-e delete --confirm retain {{ pwe_retain }}'
           WorkingDirectory={{ pwe_venv }}
           User=postgres
 

--- a/shared-roles/postgresql-wal-e/vars/main.yml
+++ b/shared-roles/postgresql-wal-e/vars/main.yml
@@ -1,1 +1,2 @@
 pwe_venv: /var/lib/postgresql/wal-e
+pwe_retain: 5


### PR DESCRIPTION
This will add service alongside the base-backup service and timer that
will use wal-e to delete the oldest base-backups after making new
base-backups each sunday night.

The number 5 is picked a bit at random, it doesn't seem we run out of
disk that often.

There might be a better way to trigger this than a timer, but I am not
that experienced with systemd services.

Attempts to fix #138