### PR TITLE
make sure that we redirect to the wiki, not to bitraf main website

### DIFF
--- a/templates/nginx/mediawiki/sites-enabled/mediawiki
+++ b/templates/nginx/mediawiki/sites-enabled/mediawiki
@@ -86,7 +86,7 @@ server {
 
   # Explicit access to the root website, redirect to main page (adapt as needed)
   location = / {
-    return 301 https://bitraf.no;
+    return 301 https://wiki.bitraf.no/wiki/;
   }
 
   # Every other entry point will be disallowed.


### PR DESCRIPTION
fix so that the url wiki.bitraf.no redirects to the wiki, not bitraf.no