### PR TITLE
heim - apt - change to bullseye

### DIFF
--- a/heim/roles/packages/tasks/main.yml
+++ b/heim/roles/packages/tasks/main.yml
@@ -6,17 +6,17 @@
   copy:
     dest: /etc/apt/sources.list
     content: |
-      deb     http://ftp.no.debian.org/debian/ buster main contrib non-free
-      deb-src http://ftp.no.debian.org/debian/ buster main contrib non-free
+      deb     http://ftp.no.debian.org/debian/ bullseye main contrib non-free
+      deb-src http://ftp.no.debian.org/debian/ bullseye main contrib non-free
 
-      deb     http://security.debian.org/debian-security buster/updates main contrib non-free
-      deb-src http://security.debian.org/debian-security buster/updates main contrib non-free
+      deb     http://security.debian.org/debian-security bullseye-security main contrib non-free
+      deb-src http://security.debian.org/debian-security bullseye-security main contrib non-free
 
-      deb     http://ftp.no.debian.org/debian/ buster-updates main contrib non-free
-      deb-src http://ftp.no.debian.org/debian/ buster-updates main contrib non-free
+      deb     http://ftp.no.debian.org/debian/ bullseye-updates main contrib non-free
+      deb-src http://ftp.no.debian.org/debian/ bullseye-updates main contrib non-free
 
-      deb     http://ftp.no.debian.org/debian/ buster-backports main contrib non-free
-      deb-src http://ftp.no.debian.org/debian/ buster-backports main contrib non-free
+      deb     http://ftp.no.debian.org/debian/ bullseye-backports main contrib non-free
+      deb-src http://ftp.no.debian.org/debian/ bullseye-backports main contrib non-free
 
 
 - name: install debian packages


### PR DESCRIPTION
I'm upgrading heim from buster (Debian 10) to bullseye (Debian 11).