### PR TITLE
heim: Debian 11 have php7.4, not php7.3

### DIFF
--- a/heim/roles/packages/tasks/main.yml
+++ b/heim/roles/packages/tasks/main.yml
@@ -54,5 +54,5 @@
     - nginx
 
     # user requests
-    - php7.3
+    - php7.4
     - php


### PR DESCRIPTION
Debian 11 have php7.4, not php7.3, so perhaps we should change it, unless the user request was specifically for php 7.3?