### PR TITLE
mqtt: add account bitraf-homeassistant

### DIFF
--- a/bomba/host_vars/bomba/mosquitto.yml
+++ b/bomba/host_vars/bomba/mosquitto.yml
@@ -2,3 +2,4 @@ mqtt_accounts:
   - name: bitraf-p2k16-web
   - name: bitraf-p2k16-web-staging
   - name: bitraf-tool-lock
+  - name: bitraf-homeassistant


### PR DESCRIPTION
the homeassistant account needs to be put into "mqtt_accounts" too. There is probably a way to do this without duplicating info from the passwords file (the names are already there), but I can't see it just now.