### PR TITLE
bomba: add the postfix-satellite role

### DIFF
--- a/bomba/bomba.yml
+++ b/bomba/bomba.yml
@@ -4,6 +4,7 @@
     - bitraf-base
     - superusers
     - lusers
+    - postfix-satellite
   vars_files:
     - ../vars/bitraf_passwords.yml
     - ../vars/users.yml


### PR DESCRIPTION
we use postfix on all our other machines, so do it on this one too.