### PR TITLE
Add role wireless network

### DIFF
--- a/shared-roles/wireless-network/README.md
+++ b/shared-roles/wireless-network/README.md
@@ -1,0 +1,10 @@
+A role to configure the wireless network on Raspberry Pi, running RaspiOS (Raspbian).
+
+You will need to define
+
+    wifi_ssid: <ssid>
+    wifi_psk: <psk>
+
+in a file ../../host_vars/<hostname>/wifi.yml
+
+and encrypt it with ansible-vault before this role will work. NOTE: remember to encrypt before the file leaves your machine!

--- a/shared-roles/wireless-network/defaults/main.yml
+++ b/shared-roles/wireless-network/defaults/main.yml
@@ -1,0 +1,1 @@
+wifi__country: "NO"

--- a/shared-roles/wireless-network/handlers/main.yml
+++ b/shared-roles/wireless-network/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: Restart Networking
+  become: yes
+  service:
+    name: networking
+    state: restarted

--- a/shared-roles/wireless-network/tasks/main.yml
+++ b/shared-roles/wireless-network/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: configure wireless network
+  tags: wireless-network
+  block:
+  - name: Install system dependencies
+    apt:
+      name:
+      - wpasupplicant
+  - name: Configure wpa_supplicant
+    template:
+      src: wpa_supplicant.conf.j2
+      dest: /etc/wpa_supplicant/wpa_supplicant.conf
+      backup: yes
+  - name: make wpa_supplicant re-read it's configuration file
+    become: yes
+    command: "wpa_cli -i wlan0 reconfigure"
+    notify: Restart Networking

--- a/shared-roles/wireless-network/templates/wpa_supplicant.conf.j2
+++ b/shared-roles/wireless-network/templates/wpa_supplicant.conf.j2
@@ -1,0 +1,11 @@
+# managed with ansible
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+p2p_disabled=1
+country={{ wifi__country }}
+
+network={
+    #scan_ssid=1
+    ssid="{{ wifi_ssid }}"
+    psk="{{ wifi_psk }}"
+}


### PR DESCRIPTION
Adds a shared role called "wireless-network" used to configure wireless networking on a Raspberry Pi (it might work with similar operating systems, but that has not been tested) running RaspiOS / Raspbian. Sets a country, and values for ssid and psk (must be defined first, see README).